### PR TITLE
Adicionando Integração Continua

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        working-directory: ./api
+        run: yarn install
+      - name: Run tests
+        working-directory: ./api
+        run: yarn jest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
-      - "master"
+      - "main"
 
 jobs:
   build:
@@ -33,4 +33,4 @@ jobs:
         run: yarn install
       - name: Run tests
         working-directory: ./api
-        run: yarn jest
+        run: yarn test


### PR DESCRIPTION
Através do arquivo `.github/workflows/ci.yml`, qualquer código só será aceito através das *pull_request*, se passar em todos os testes.